### PR TITLE
Chore: Add Swift CI workflow

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -1,0 +1,59 @@
+name: Swift
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  macos:
+    name: macOS Build & Test
+    runs-on: macos-15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Swift version
+        run: swift --version
+
+      - name: Cache SwiftPM
+        uses: actions/cache@v4
+        with:
+          path: |
+            .build
+            ~/Library/Caches/org.swift.swiftpm
+            ~/Library/org.swift.swiftpm
+          key: spm-${{ runner.os }}-${{ hashFiles('Package.resolved', 'Package.swift') }}
+          restore-keys: |
+            spm-${{ runner.os }}-
+
+      - name: Resolve dependencies
+        run: swift package resolve
+
+      - name: Build
+        run: swift build
+
+      - name: Test
+        run: swift test --parallel
+
+  ios:
+    name: iOS Build
+    runs-on: macos-15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build for iOS Simulator
+        run: |
+          xcodebuild build \
+            -scheme GLiNER2Swift \
+            -destination 'generic/platform=iOS Simulator' \
+            -skipPackagePluginValidation \
+            -derivedDataPath .build/derivedData \
+            CODE_SIGNING_ALLOWED=NO


### PR DESCRIPTION
**What**

Adds `.github/workflows/swift.yml` with two jobs:
- **macOS Build & Test** — `swift build` + `swift test --parallel` on `macos-15` (Apple Silicon, what MLX requires), with SwiftPM caching.
- **iOS Build** — `xcodebuild` against an iOS Simulator destination to keep the iOS support landed in #11 from rotting.

Triggers on PRs to `main`, pushes to `main`, and manual dispatch. A `concurrency` group cancels superseded runs.

**Why**

Previously the only workflow was `codeql.yml` on a weekly cron — PRs merged without anyone running the parity test suite, which is risky for a numerical port. Tests that need external weights/fixtures already `XCTSkip` cleanly, so the workflow runs the component-level parity tests against the committed `.safetensors` fixtures and skips the rest.

**Affected Areas**

- New: `.github/workflows/swift.yml`
- No source or test changes.

**More Info**

- The README badge update lives in a separate PR so this one can land independently.
- `macos-15` is required for the Xcode/Swift versions MLX-Swift needs and for iOS 17+ Simulator availability.