### PR TITLE
Support multilingual (mdeberta-v3-base) checkpoints

### DIFF
--- a/Sources/GLiNER2Swift/Config/ExtractorConfig.swift
+++ b/Sources/GLiNER2Swift/Config/ExtractorConfig.swift
@@ -39,8 +39,11 @@ public struct ExtractorConfig: Codable, Sendable {
     /// Hidden size from encoder (default: 768 for DeBERTa-base)
     public let hiddenSize: Int
 
-    /// Vocabulary size including special tokens (default: 128011)
-    public let vocabSize: Int
+    /// Vocabulary size including special tokens (default: 128011). Lives in
+    /// `encoder_config/config.json`, not the top-level config — multilingual models
+    /// (mdeberta-v3-base) use 250112, so it must be read there or the word-embedding
+    /// is built at the wrong size and high token ids decode to garbage.
+    public var vocabSize: Int
 
     /// Maximum count value for CountLSTM (default: 20)
     public let maxCount: Int

--- a/Sources/GLiNER2Swift/GLiNER2.swift
+++ b/Sources/GLiNER2Swift/GLiNER2.swift
@@ -105,8 +105,17 @@ public class GLiNER2 {
             }
         }
 
-        // 1. Load configuration
-        let config = try ExtractorConfig.load(from: configUrl)
+        // 1. Load configuration. The encoder's true vocab_size lives in
+        //    encoder_config/config.json (the top-level config omits it); without
+        //    this the word-embedding is built at the default 128011 and any model
+        //    with a larger vocab (mdeberta-v3-base = 250112) decodes to garbage.
+        var config = try ExtractorConfig.load(from: configUrl)
+        let encoderConfigUrl = baseUrl.appendingPathComponent("encoder_config/config.json")
+        if let encData = try? Data(contentsOf: encoderConfigUrl),
+           let enc = try? JSONSerialization.jsonObject(with: encData) as? [String: Any],
+           let vocab = enc["vocab_size"] as? Int, vocab > 0 {
+            config.vocabSize = vocab
+        }
 
         // 2. Initialize processor with tokenizer
         let poolingType: TokenPoolingType

--- a/Sources/GLiNER2Swift/Layers/CountLSTM.swift
+++ b/Sources/GLiNER2Swift/Layers/CountLSTM.swift
@@ -20,6 +20,14 @@
 import MLX
 import MLXNN
 
+/// Count-aware label projection. Two backbone variants exist (`count_lstm`
+/// projector vs `count_lstm_v2` transformer) selected by the model config; both
+/// turn label embeddings into count-aware structure projections for span scoring.
+public protocol CountEmbedding: Module {
+    func callAsFunction(_ pcEmb: MLXArray, goldCountVal: Int) -> MLXArray
+    func loadWeights(_ weights: [String: MLXArray], prefix: String)
+}
+
 // MARK: - CountLSTM (Basic Version)
 
 /// Basic CountLSTM using GRU with MLP projector.
@@ -30,7 +38,7 @@ import MLXNN
 ///   h0 = pc_emb.unsqueeze(0)  # (1, M, D)
 ///   output, _ = gru(pos_seq, h0)  # (L, M, D)
 ///   return projector(cat([output, pc_emb.expand], dim=-1))  # (L, M, D)
-public class CountLSTM: Module {
+public class CountLSTM: Module, CountEmbedding {
     public let hiddenSize: Int
     public let maxCount: Int
 
@@ -113,7 +121,7 @@ public class CountLSTM: Module {
 ///   output, _ = gru(pos_seq, h0)           # (L, M, D)
 ///   pc_broadcast = pc_emb.unsqueeze(0).expand_as(output)
 ///   return transformer(output + pc_broadcast)  # ← ADDITION here!
-public class CountLSTMv2: Module {
+public class CountLSTMv2: Module, CountEmbedding {
     public let hiddenSize: Int
     public let maxCount: Int
 

--- a/Sources/GLiNER2Swift/Model/Extractor.swift
+++ b/Sources/GLiNER2Swift/Model/Extractor.swift
@@ -52,8 +52,9 @@ public class Extractor: Module {
     /// Count prediction layer: hidden → 2*hidden → 20
     public let countPred: Sequential
 
-    /// Count embedding module (CountLSTMv2 for gliner2-base-v1)
-    public let countEmbed: CountLSTMv2
+    /// Count embedding module — variant chosen by config.countingLayer
+    /// (count_lstm = CountLSTM projector; count_lstm_v2 = CountLSTMv2 transformer).
+    public let countEmbed: CountEmbedding
 
     /// Initialize Extractor from configuration
     ///
@@ -107,11 +108,16 @@ public class Extractor: Module {
             addLayerNorm: false
         )
 
-        // Initialize count embedding
-        self.countEmbed = CountLSTMv2(
-            hiddenSize: hiddenSize,
-            maxCount: config.maxCount
-        )
+        // Initialize count embedding — the backbone variant the checkpoint uses.
+        // Multilingual gliner2-multi-v1 uses count_lstm (projector); the English
+        // base uses count_lstm_v2 (transformer). Building the wrong one leaves its
+        // weights unloaded (random) and silently garbles span scoring.
+        switch config.countingLayer {
+        case .countLSTM:
+            self.countEmbed = CountLSTM(hiddenSize: hiddenSize, maxCount: config.maxCount)
+        case .countLSTMv2, .countLSTMMoE:
+            self.countEmbed = CountLSTMv2(hiddenSize: hiddenSize, maxCount: config.maxCount)
+        }
     }
 
     // MARK: - Encoder Forward
@@ -162,10 +168,12 @@ public class Extractor: Module {
         let endInvalid = MLX.equal(spanIdxArray[0..., 0..., 1], MLXArray(Int32(-1)))
         let spanMask = MLX.logicalOr(startInvalid, endInvalid)
 
-        // Replace invalid indices with (0, 0) for safe indexing
+        // Replace invalid indices with (0, 0) for safe indexing. The zeros MUST be
+        // Int32 to match spanIdxArray — otherwise `where` promotes safeSpans to
+        // Float and the downstream gather fails ("cannot gather with indices type").
         let safeSpans = MLX.where(
             spanMask.expandedDimensions(axis: -1),
-            MLXArray.zeros([1, spansIdx.count, 2]),
+            MLXArray.zeros([1, spansIdx.count, 2], type: Int32.self),
             spanIdxArray
         )
 
@@ -261,6 +269,9 @@ extension Extractor {
         ("count_embed.transformer.transformer.layers", "countEmbed.transformer.transformerLayers"),
         ("count_embed.transformer.in_projector", "countEmbed.transformer.inProjector"),
         ("count_embed.transformer.out_projector", "countEmbed.transformer.outProjector"),
+        // count_lstm (v1) projector MLP — prefix only; CountLSTM.loadWeights maps
+        // the .0/.2 PyTorch indices onto its Sequential itself.
+        ("count_embed.projector", "countEmbed.projector"),
         // GRU keys (full terminal keys, no suffix)
         ("count_embed.gru.weight_ih_l0", "countEmbed.gru.weightIH"),
         ("count_embed.gru.weight_hh_l0", "countEmbed.gru.weightHH"),

--- a/Sources/GLiNER2Swift/Utils/WeightLoader.swift
+++ b/Sources/GLiNER2Swift/Utils/WeightLoader.swift
@@ -62,7 +62,10 @@ public func downloadModelDirectory(
     let repo = Hub.Repo(id: repoId)
     let filePatterns = [
         "*.safetensors", "config.json",
-        "tokenizer.json", "tokenizer_config.json", "special_tokens_map.json"
+        "tokenizer.json", "tokenizer_config.json", "special_tokens_map.json",
+        // The encoder's true vocab_size lives here (top-level config omits it);
+        // needed to size the word-embedding for larger-vocab backbones (mdeberta).
+        "encoder_config/config.json"
     ]
 
     do {


### PR DESCRIPTION

## Summary

Makes multilingual GLiNER2 checkpoints work — e.g. [`fastino/gliner2-multi-v1`](https://huggingface.co/fastino/gliner2-multi-v1) (mDeBERTa-v3-base backbone, fr/en/es/de/it/pt). Before this, such models loaded without error but decoded to **garbage spans** (fragment text, ~0.5 confidences); only the English `deberta-v3-base` base model produced correct output. This is the "Additional GLiNER models … not yet available" item from the README.

## Diagnosis

The bug was isolated by comparing intermediates against the Python `gliner2` reference on identical input. For `fastino/gliner2-multi-v1`, **all of these were byte-identical** to Python:

- the built `input_ids` (schema + text),
- the encoder hidden states (mean/std and per-token vectors),
- the subword→word pooled embeddings,
- the `span_rep` output.

That narrowed the divergence to the **count-aware scoring head**, where `count_embed` projects the label embeddings before the span-scoring einsum.

## Changes (4 fixes)

1. **`vocab_size` is read from `encoder_config/config.json`.** The top-level `config.json` omits it, so it fell back to the default `128011` and the word-embedding was built too small for the multilingual 250112-token vocab. (`GLiNER2.fromPretrained`, `ExtractorConfig.vocabSize` made mutable.)
2. **`downloadModelDirectory` now fetches `encoder_config/config.json`** (added to the snapshot file patterns) so the value above is available.
3. **The count layer is built per `config.countingLayer`.** `count_lstm` → `CountLSTM` (GRU + MLP projector); `count_lstm_v2` → `CountLSTMv2` (GRU + DownscaledTransformer). It was hardcoded to `CountLSTMv2`, so `count_lstm` checkpoints loaded those (absent) transformer weights as **random**, silently garbling every span score. A small `CountEmbedding` protocol abstracts the two variants; a `count_embed.projector` key-remap entry is added.
4. **`safeSpans` invalid-index zeros are `Int32`, not `Float`.** `MLX.where` was promoting the span indices to `Float`, which made the downstream gather fail with *"cannot gather with indices type"* on the CPU backend.

## Verification

`fastino/gliner2-multi-v1` now matches the Python reference on both **CPU and GPU**:

```
EN  character: Cato 0.9996, Clove 0.9995, Thresh 0.9995, Peeta 0.992
EN  place:     District 12 0.97, cave 0.74, stream 0.67
FR  personnage: Charles 0.9999, Emma 0.999    lieu: Rouen 0.995
```

The English `fastino/gliner2-base-v1` continues to produce identical results to before (the count-layer switch defaults to `CountLSTMv2`).

## Notes

- Relation extraction for these checkpoints is still the separate WIP item.
- The README's "currently only `deberta-v3-base` is supported" line can be relaxed.
